### PR TITLE
Multiple grouping

### DIFF
--- a/CK2Editor/CK2Editor.csproj
+++ b/CK2Editor/CK2Editor.csproj
@@ -41,6 +41,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="EntryEventArgs.cs" />
+    <Compile Include="EntryGrouper.cs" />
     <Compile Include="FormattedReader.cs" />
     <Compile Include="Entry.cs" />
     <Compile Include="SectionEntry.cs" />

--- a/CK2Editor/Entry.cs
+++ b/CK2Editor/Entry.cs
@@ -22,13 +22,24 @@ namespace CK2Editor
         /// </summary>
         public string Link { get; set; }
         /// <summary>
-        /// The editor that edits this entry. Can be null if not part of an editors' tree
-        /// </summary>
-        //public SectionEntry SectionEntry { get; set; }
-        /// <summary>
         /// The parent SectionEntry of this entry
         /// </summary>
         public SectionEntry Parent { get; set; }
+        /// <summary>
+        /// The first parent of this entry that is present in the file (i.e. not a grouper)
+        /// </summary>
+        public SectionEntry RealParent
+        {
+            get
+            {
+                SectionEntry cur = Parent;
+                while (cur.IsGrouper)
+                {
+                    cur = cur.Parent;
+                }
+                return cur;
+            }
+        }
 
         public SectionEntry Root { get; set; }
 

--- a/CK2Editor/EntryGrouper.cs
+++ b/CK2Editor/EntryGrouper.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CK2Editor
+{
+    public class EntryGrouper : SectionEntry
+    {
+        public override bool IsGrouper { get { return true; } }
+    }
+}

--- a/CK2Editor/Formats/CK2Save.xml
+++ b/CK2Editor/Formats/CK2Save.xml
@@ -7,7 +7,7 @@
     <type name="Type" type="number" />
   </player>
   <player_realm name="Player Realm" type="string" />
-  <dyn_title name="Dyn Title" multiple="same">
+  <dyn_title name="Dyn Title" multiple="same" grouper-name="(Dynamic Titles)">
     <title name="Title" type="string" />
     <base_title name="Base Title" type="string" />
     <is_custom name="Is Custom" type="misc" />
@@ -35,27 +35,27 @@
     <sabuktigin_spawned_by_event name="Sabuktigin Spawned By Event" type="date" />
   </flags>
   <dynasties name="Dynasties">
-    <NUMBER name="NUMBER" multiple="number">
+    <DYNASTY name="[!/name:[VALUE]!]" multiple="number" grouper-name="(Dynsaties)">
       <name name="Name" type="string" />
       <culture name="Culture" type="string" />
       <religion name="Religion" type="string" link="!/religion/THISVALUE" />
       <coat_of_arms name="Coat Of Arms">
         <data name="Data">
-          <ENTRY name="Entry" multiple="blank" type="number" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </data>
         <religion name="Religion" type="string" link="!/religion/THISVALUE" />
       </coat_of_arms>
-    </NUMBER>
+    </DYNASTY>
   </dynasties>
   <character name="Character">
-    <CHARACTER name="NUMBER" multiple="number">
+    <CHARACTER name="[!/birth_name:[VALUE]!]" multiple="number" grouper-name="(Characters)">
       <birth_name name="Birth Name" type="string" />
       <birth_date name="Birth Date" type="string" />
       <attributes name="Attributes">
-        <ENTRY name="Entry" multiple="blank" type="number" />
+        <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
       </attributes>
       <traits name="Traits">
-        <ENTRY name="Entry" multiple="blank" type="number" />
+        <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
       </traits>
       <religion name="Religion" type="string" link="!/religion/THISVALUE" />
       <culture name="Culture" type="string" />
@@ -72,16 +72,16 @@
         <capital name="Capital" type="string" />
         <liege_troops name="Liege Troops">
           <light_infantry_f name="Light Infantry F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </light_infantry_f>
           <heavy_infantry_f name="Heavy Infantry F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </heavy_infantry_f>
           <archers_f name="Archers F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </archers_f>
           <galleys_f name="Galleys F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </galleys_f>
         </liege_troops>
         <my_liegelevy_contribution name="My Liegelevy Contribution" type="number" />
@@ -89,7 +89,7 @@
         <economy_techpoints name="Economy Techpoints" type="number" />
         <culture_techpoints name="Culture Techpoints" type="number" />
         <liegelevy_reinforcements name="Liegelevy Reinforcements">
-          <ENTRY name="Entry" multiple="blank" type="misc" />
+          <ENTRY name="Entry" multiple="blank" type="misc" grouper-name="(Data)" />
         </liegelevy_reinforcements>
       </demesne>
       <title name="Title" type="string" />
@@ -104,16 +104,16 @@
       <averaged_income name="Averaged Income" type="number" />
       <ledger name="Ledger">
         <income name="Income">
-          <ENTRY name="Entry" multiple="blank" type="number" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </income>
         <lastmonthincometable name="Last Month Income Table">
-          <ENTRY name="Entry" multiple="blank" type="misc" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </lastmonthincometable>
         <expense name="Expense">
-          <ENTRY name="Entry" multiple="blank" type="misc" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </expense>
         <lastmonthexpensetable name="Last Month Expense Table">
-          <ENTRY name="Entry" multiple="blank" type="misc" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </lastmonthexpensetable>
         <lastmonthincome name="Last Month Income" type="number" />
         <lastmonthexpense name="Last Month Expense" type="number" />
@@ -131,7 +131,7 @@
       <ambition_date name="Ambition Date" type="string" />
     </CHARACTER>
   </character>
-  <delayed_event name="Delayed Event" multiple="same">
+  <delayed_event name="Delayed Event" multiple="same" grouper-name="(Delayed Events)" >
     <event name="Event" type="string" />
     <days name="Days" type="number" />
     <scope name="Scope">
@@ -167,7 +167,7 @@
   </delayed_event>
   <relation name="Realtions">
     <RELATION name="Relation">
-      <OPINION_WITH name="Opinion With [!!/character/[THISVALUE]:[VNAME]!]" multiple="number">
+      <OPINION_WITH name="Opinion With [!!/character/[THISVALUE]:[VNAME]!]" multiple="number" grouper-name="(Opinions)">
         <OPINION name="Opinion Modifier">
           <modifier name="Modifier" type="string" />
           <date name="Expiration Date" type="string" />
@@ -175,7 +175,7 @@
       </OPINION_WITH>
     </RELATION>
   </relation>
-  <active_ambition name="Active Ambition" multiple="same">
+  <active_ambition name="Active Ambition" multiple="same" grouper-name="(Active Ambitions)">
     <type name="Type" type="string" />
     <scope name="Scope">
       <char name="Char" type="number" />
@@ -193,7 +193,7 @@
       <random name="Random" type="number" />
     </parent_scope>
   </active_ambition>
-  <active_focus name="Active Focus" multiple="same">
+  <active_focus name="Active Focus" multiple="same" grouper-name="(Active Foci)">
     <type name="Type" type="string" />
     <scope name="Scope">
       <char name="Char" type="number" />
@@ -211,7 +211,7 @@
       <random name="Random" type="number" />
     </parent_scope>
   </active_focus>
-  <active_plot name="Active Plot" multiple="same">
+  <active_plot name="Active Plot" multiple="same" grouper-name="(Active Plots)">
     <type name="Type" type="string" />
     <scope name="Scope">
       <char name="Char" type="number" />
@@ -230,7 +230,7 @@
     </parent_scope>
     <auto_invite name="Auto Invite" type="misc" />
   </active_plot>
-  <active_faction name="Active Faction" multiple="same">
+  <active_faction name="Active Faction" multiple="same" grouper-name="(Active Factions)" >
     <type name="Type" type="string" />
     <scope name="Scope">
       <new_char name="Proposed Character" type="number" />
@@ -256,21 +256,21 @@
     <type name="Type" type="number" />
   </id>
   <religion name="Religion">
-    <RELIGION name="Catholic" multiple="different">
+    <RELIGION name="Catholic" multiple="different" grouper-name="(Religions)">
       <last_crusade name="Last Crusade/Jihad/Great Holy War" type="string" />
       <parent name="Parent" type="string" />
       <original_parent name="Original Parent" type="string" />
       <was_heresy name="Was Heresy" type="misc" />
       <reformed name="Reformed Religion" type="string" />
       <original_reformed name="Original Reformed Religion" type="string" />
-      <authority name="Authority Modifier" multiple="same">
+      <authority name="Authority Modifier" multiple="same" grouper-name="(Authority Modifiers)">
         <modifier name="Modifier" type="string" />
         <date name="Expiration Date" type="string" />
       </authority>
     </RELIGION>
   </religion>
   <provinces name="Provinces">
-    <PROVINCE name="NUMBER" multiple="number">
+    <PROVINCE name="NUMBER" multiple="number" grouper-name="(Provinces)">
       <name name="Name" type="string" />
       <culture name="Culture" type="misc" />
       <religion name="Religion" type="misc" link="!/religion/THISVALUE" />
@@ -292,28 +292,28 @@
         <ca_stable_2 name="Ca Stable 2" type="misc" />
         <levy name="Levy">
           <light_infantry_f name="Light Infantry F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </light_infantry_f>
           <heavy_infantry_f name="Heavy Infantry F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </heavy_infantry_f>
           <pikemen_f name="Pikemen F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </pikemen_f>
           <light_cavalry_f name="Light Cavalry F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </light_cavalry_f>
           <archers_f name="Archers F">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </archers_f>
           <galleys_f name="Galleys F">
-            <ENTRY name="Entry" multiple="blank" type="misc" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </galleys_f>
         </levy>
       </b_reykjavik>
       <technology name="Technology">
         <tech_levels name="Tech Levels">
-          <ENTRY name="Entry" multiple="blank" type="misc" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(data)" />
         </tech_levels>
       </technology>
       <lootable_gold name="Lootable Gold" type="number" />
@@ -330,10 +330,10 @@
       <holder name="Current Holder" type="number" link="!/character/[THISVALUE]" />
       <succession name="Succession Law" type="misc" />
       <gender name="Gender Law" type="misc" />
-      <law name="Law" type="string" multiple="same" />
+      <law name="Law" type="string" multiple="same" grouper-name="(Laws)" />
       <coat_of_arms name="Coat Of Arms">
         <data name="Data">
-          <ENTRY name="Entry" multiple="blank" type="number" />
+          <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
         </data>
         <religion name="Religion" type="string" link="!/religion/THISVALUE" />
       </coat_of_arms>
@@ -341,14 +341,14 @@
       <de_jure_law_changes name="De Jure Law Changes" type="number" />
       <last_change name="Last De Jure Law Change" type="string" />
       <previous name="Previous Holders">
-        <HOLDER name="Holder" multiple="blank" type="number" link="!/character/[THISVALUE]" />
+        <HOLDER name="Holder" multiple="blank" type="number" link="!/character/[THISVALUE]" grouper-name="(Holders)" />
       </previous>
       <set_the_kings_peace name="Set The Kings Peace" type="misc" />
       <set_protected_inheritance name="Set Protected Inheritance" type="misc" />
       <set_allow_title_revokation name="Allow Title Revokation" type="misc" />
       <set_allow_free_infidel_revokation name="Allow Free Title Revokation From Infidel" type="misc" />
       <history name="History">
-        <DATE name="[!THISNAME!]" multiple="date">
+        <DATE name="[!THISNAME!]" multiple="date" grouper-name="(Holders)">
           <holder name="Holder" type="number" link="!/character/[THISVALUE]" />
         </DATE>
       </history>
@@ -356,8 +356,8 @@
   </title>
   <diplomacy name="Diplomacy" />
   <combat name="Combat">
-    <siege_combat name="Siege" multiple="same">
-      <attackers name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" />
+    <siege_combat name="Siege" multiple="same"  grouper-name="(Sieges)">
+      <attackers name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" grouper-name="(Attackers)" />
       <location name="Location" type="number" link="!/provinces/[THISVALUE]" />
       <day name="Day" type="number" />
       <attacker name="Attacker">
@@ -370,27 +370,27 @@
           <last_leader name="Last Leader" type="number" link="!/character/[THISVALUE]" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <pikemen_f name="Pikemen F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </pikemen_f>
             <light_cavalry_f name="Light Cavalry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_cavalry_f>
             <archers_f name="Archers">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
             <horse_archers name="Horse Archers">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </horse_archers>
           </losses>
           <target name="Target Flank" type="number" />
           <sub_unit name="Sub Units">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </sub_unit>
           <tactic name="Tactic" type="number" />
           <tactic_day name="Tactic Day" type="number" />
@@ -403,19 +403,19 @@
           <last_leader name="Last Leader" type="number" link="!/character/[THISVALUE]" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <pikemen_f name="Pikemen">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </pikemen_f>
             <light_cavalry_f name="Light Cavalry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_cavalry_f>
             <archers_f name="Archers">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
           </losses>
           <target name="Target" type="number" />
@@ -427,13 +427,13 @@
       <event name="Event" type="number" />
       <adjacencies name="Adjacencies" type="number" />
     </siege_combat>
-    <land_combat name="Land Combat" multiple="same">
-      <attackers name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" />
-      <defenders name="Defender" type="number" multiple="same" link="!/character/[THISVALUE]" />
+    <land_combat name="Land Combat" multiple="same"  grouper-name="(Land Battles)">
+      <attackers name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" grouper-name="(Attackers)" />
+      <defenders name="Defender" type="number" multiple="same" link="!/character/[THISVALUE]" grouper-name="(Defenders)" />
       <location name="Location" type="number" link="!/provinces/[THISVALUE]" />
       <day name="Day" type="number" />
       <attacker name="Attacker">
-        <unit name="Unit" multiple="same">
+        <unit name="Unit" multiple="same" grouper-name="(Units)">
           <id name="Id" type="number" />
           <type name="Type" type="number" />
         </unit>
@@ -444,18 +444,18 @@
           <last_leader name="Last Leader" type="number" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry">
-              <ENTRY name="Entry" multiple="blank" type="number" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry">
-              <ENTRY name="Entry" multiple="blank" type="number" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <archers_f name="Archers">
-              <ENTRY name="Entry" multiple="blank" type="number" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
           </losses>
           <target name="Target" type="number" />
           <sub_unit name="Sub Units">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </sub_unit>
           <tactic name="Tactic" type="number" />
           <tactic_day name="Tactic Day" type="number" />
@@ -464,7 +464,7 @@
         </flank_center>
       </attacker>
       <defender name="Defender">
-        <unit name="Unit" multiple="same">
+        <unit name="Unit" multiple="same" grouper-name="(Units)">
           <id name="Id" type="number" />
           <type name="Type" type="number" />
         </unit>
@@ -473,24 +473,24 @@
           <last_leader name="Last Leader" type="number" link="!/character/[THISVALUE]" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <pikemen_f name="Pikemen">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </pikemen_f>
             <light_cavalry_f name="Light Cavalry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_cavalry_f>
             <archers_f name="Archers">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
           </losses>
           <target name="Target" type="number" />
           <sub_unit name="Sub Unit">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </sub_unit>
           <tactic name="Tactic" type="number" />
           <tactic_day name="Tactic Day" type="number" />
@@ -502,24 +502,24 @@
           <last_leader name="Last Leader" type="number" link="!/character/[THISVALUE]" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <pikemen_f name="Pikemen">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </pikemen_f>
             <light_cavalry_f name="Light Cavalry">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_cavalry_f>
             <archers_f name="Archers">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
           </losses>
           <target name="Target" type="number" />
           <sub_unit name="Sub Unit">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </sub_unit>
           <tactic name="Tactic" type="number" />
           <tactic_day name="Tactic Day" type="number" />
@@ -531,24 +531,24 @@
           <last_leader name="Last Leader" type="number" link="!/character/[THISVALUE]" />
           <losses name="Losses">
             <light_infantry_f name="Light Infantry F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_infantry_f>
             <heavy_infantry_f name="Heavy Infantry F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </heavy_infantry_f>
             <pikemen_f name="Pikemen F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </pikemen_f>
             <light_cavalry_f name="Light Cavalry F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </light_cavalry_f>
             <archers_f name="Archers F">
-              <ENTRY name="Entry" multiple="blank" type="misc" />
+              <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
             </archers_f>
           </losses>
           <target name="Target" type="number" />
           <sub_unit name="Sub Unit">
-            <ENTRY name="Entry" multiple="blank" type="number" />
+            <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
           </sub_unit>
           <tactic name="Tactic" type="number" />
           <tactic_day name="Tactic Day" type="number" />
@@ -564,10 +564,10 @@
     <name name="Name" type="string" />
     <history name="History" />
   </war>
-  <active_war name="Active War" multiple="same">
+  <active_war name="Active War" multiple="same" grouper-name="(Active Wars)">
     <name name="Name" type="string" />
-    <attacker name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" />
-    <defender name="Defender" type="number" multiple="same" link="!/character/[THISVALUE]" />
+    <attacker name="Attacker" type="number" multiple="same" link="!/character/[THISVALUE]" grouper-name="(Attackers)" />
+    <defender name="Defender" type="number" multiple="same" link="!/character/[THISVALUE]"  grouper-name="(Defenders)" />
     <casus_belli name="Casus Belli">
       <casus_belli name="Casus Belli Name" type="string" />
       <actor name="Actor" type="number" />
@@ -575,7 +575,7 @@
       <date name="Date" type="string" />
     </casus_belli>
     <history name="War History">
-      <EVENT name="DATE" multiple="date">
+      <EVENT name="Event" multiple="date"  grouper-name="(War Events)">
         <add_defender name="Defender Joined" type="number" link="!/character/[THISVALUE]" />
         <add_attacker name="Attacker Joined" type="number" link="!/character/[THISVALUE]" />
       </EVENT>
@@ -590,7 +590,7 @@
     </defender_participation>
   </active_war>
   <previous_war name="Previous Wars">
-    <ENTRY name="Entry" multiple="blank" type="number" />
+    <ENTRY name="Entry" multiple="blank" type="number" grouper-name="(Data)" />
   </previous_war>
   <next_outbreak_id name="Next Outbreak Id" type="number" />
   <disease name="Disease">
@@ -619,7 +619,7 @@
   <income_statistics name="Income Statistics" />
   <nation_size_statistics name="Nation Size Statistics" />
   <character_history name="Played Character History">
-    <CHARACTER name="Past Character" multiple="blank" link="!/character/[THISVALUE]">
+    <CHARACTER name="Past Character" multiple="blank" link="!/character/[THISVALUE]" grouper-name="(Past Characters)">
       <identity name="Character" type="number" link="!/character/[THISVALUE]" />
       <date name="Play Start Date" type="string" />
       <score name="Score" type="number" />

--- a/CK2Editor/FormattedReader.cs
+++ b/CK2Editor/FormattedReader.cs
@@ -131,7 +131,7 @@ namespace CK2Editor
                 {
                     grouper = new EntryGrouper();
                     grouper.InternalName = node.LocalName;
-                    grouper.FriendlyName = node.Attributes["name"].Value;
+                    grouper.FriendlyName = node.Attributes["grouper-name"].Value;
                     multiples[multAtt.Value] = grouper;
                     parent.Entries.Add(grouper);
                 }

--- a/CK2Editor/FormattedReader.cs
+++ b/CK2Editor/FormattedReader.cs
@@ -51,14 +51,16 @@ namespace CK2Editor
             root = root != null ? root : re;//if no root was provided, the current editor is the root
             re.Root = root;
 
-            //if (new System.Diagnostics.StackTrace().FrameCount == 14)
-            //System.Diagnostics.Debugger.Break();
-
+            Dictionary<string, EntryGrouper> multiples = null;
             foreach (var pair in FormatUtil.ListEntriesWithIndexes(file))
             {
+                SectionEntry parent = re;
+
                 XmlNode childNode = FindNode(formatNode, pair.Value);//look for a format node that can describe this entry
                 if (childNode != null)
                 {
+                    parent = HandleMultiples(childNode, ref multiples, re);
+
                     if (!childNode.HasChildNodes)
                     {//the node is a value
                         ValueEntry ent = new ValueEntry();
@@ -67,9 +69,9 @@ namespace CK2Editor
                         ent.Type = childNode.Attributes["type"] != null ? childNode.Attributes["type"].Value : "misc";
                         ent.Value = FormatUtil.ReadValue(file, ent.InternalName, ent.Type, pair.Key);
                         ent.Link = childNode.Attributes["link"] != null ? childNode.Attributes["link"].Value : null;
-                        ent.Parent = re;
+                        ent.Parent = parent;
                         ent.Root = root;
-                        re.Entries.Add(ent);
+                        parent.Entries.Add(ent);
                     }
                     else
                     {//the node is a section
@@ -77,8 +79,8 @@ namespace CK2Editor
                         ent.InternalName = pair.Value;
                         ent.FriendlyName = childNode.Attributes["name"].Value;
                         ent.Link = childNode.Attributes["link"] != null ? childNode.Attributes["link"].Value : null;
-                        ent.Parent = re;
-                        re.Entries.Add(ent);
+                        ent.Parent = parent;
+                        parent.Entries.Add(ent);
                     }
                 }
                 else //if no format node was found, try to supplement information
@@ -92,19 +94,49 @@ namespace CK2Editor
                         ent.Value = FormatUtil.ReadValue(file, ent.InternalName, ent.Type, pair.Key);
                         ent.Parent = re;
                         ent.Root = root;
-                        re.Entries.Add(ent);
+                        parent.Entries.Add(ent);
                     }
                     else
                     {//the node is a section
                         SectionEntry ent = new SectionEntry();
                         ent.InternalName = pair.Value;
                         ent = ReadSection(FormatUtil.ExtractDelimited(file, pair.Value, pair.Key), childNode, re.Root);
-                        ent.Parent = re;
-                        re.Entries.Add(ent);
+                        ent.Parent = parent;
+                        parent.Entries.Add(ent);
                     }
                 }
             }
             return re;
+        }
+
+        /// <summary>
+        /// Checks if the node has the "multiple" attribute, and if so, initializes a dictionary entry for its grouper if one does not yet exist
+        /// </summary>
+        /// <param name="node">The xml node that describes the current entry</param>
+        /// <param name="multiples">The dictionary holding the multiples groupers for the current section</param>
+        /// <param name="parent">The parent of the current entry</param>
+        /// <returns><paramref name="parent"/> if the "multiple" attribute was not found, and the grouper otherwise</returns>
+        private SectionEntry HandleMultiples(XmlNode node, ref Dictionary<string, EntryGrouper> multiples, SectionEntry parent)
+        {
+            XmlAttribute multAtt = node.Attributes["multiple"];
+            if (multAtt == null)
+                return parent;
+            else
+            {
+                EntryGrouper grouper = null;
+
+                if (multiples == null)
+                    multiples = new Dictionary<string, EntryGrouper>();
+                if (!multiples.TryGetValue(multAtt.Value, out grouper))
+                {
+                    grouper = new EntryGrouper();
+                    grouper.InternalName = node.LocalName;
+                    grouper.FriendlyName = node.Attributes["name"].Value;
+                    multiples[multAtt.Value] = grouper;
+                    parent.Entries.Add(grouper);
+                }
+                return grouper;
+            }
         }
 
         public static string DetectType(string file, KeyValuePair<int, string> pair)

--- a/CK2Editor/SectionEntry.cs
+++ b/CK2Editor/SectionEntry.cs
@@ -10,6 +10,11 @@ namespace CK2Editor
 {
     public class SectionEntry : Entry
     {
+        /// <summary>
+        /// Specifies whether this section is only an abstract part of the tree and does not have a physical presence in the save file
+        /// </summary>
+        public virtual bool IsGrouper { get { return false; } }
+
         public SectionEntry()
         {
             Entries = new List<Entry>();
@@ -38,9 +43,15 @@ namespace CK2Editor
                 }
                 else if (entry is SectionEntry)
                 {
-                    FormatUtil.OutputSectionStart(sb, entry.InternalName, indent);
-                    ((SectionEntry)entry).Save(sb, indent + 1);
-                    FormatUtil.OutputSectionEnd(sb, indent);
+                    SectionEntry sEntry = ((SectionEntry)entry);
+                    if (sEntry.IsGrouper)
+                        sEntry.Save(sb, indent);
+                    else
+                    {
+                        FormatUtil.OutputSectionStart(sb, entry.InternalName, indent);
+                        sEntry.Save(sb, indent + 1);
+                        FormatUtil.OutputSectionEnd(sb, indent);
+                    }
                 }
             }
         }
@@ -55,6 +66,9 @@ namespace CK2Editor
             return sb.ToString();
         }
 
+        /// <summary>
+        /// The collection of all the entries which are contained within this section
+        /// </summary>
         public List<Entry> Entries { get; private set; }
 
         public override bool Equals(Entry other)

--- a/FormatSpec.md
+++ b/FormatSpec.md
@@ -9,15 +9,17 @@ The full format specification can be found in this document.
 
 ###Terminology
 I realize there might be confusion between the different terms used in this document, so here is a clarification:  
-+ "The file" - the CK2txt file that is being read. Not to be confused with "the format file"!  
++ "The file" / "The save file" - the CK2txt file that is being read. Not to be confused with "the format file"!  
 + "The format file" - the XML file that describes the format of the file  
 + "The (base) program" - The non-graphical part of CK2Editor  
 + "The GUI" - The graphical editing program  
-+ "Value" - An identifier-value pair in the file, like "type=66"
-+ "Section" - A section of the file delimited by curly brakcets ('{ }'), also with an identifier ("player={...}")
-+ "Entry" - A value or section
-+ "Element" - an XML elemnt in the format file
-+ "Attribute" - an XML attribute of an element
++ "Value" - An identifier-value pair in the file, like "type=66"  
++ "Section" - A section of the file delimited by curly brakcets ('{ }'), also with an identifier ("player={...}")  
++ "Entry" - A value or section  
++ "Element" - an XML element in the format file  
++ "Attribute" - an XML attribute of an element  
+
+This terminology is also applied in the documentation and inline code comments.
 
 ###Top Structure
 The format file must contain a root element called "File". This represents the entire file after the CK2txt header, and all entries should be decendants of this element.  
@@ -62,9 +64,9 @@ will evaluate to the user-friendly name of the character, because:
 
 ###General Entry syntax
 Elements in the format file should correspond to entries in the file. The name of the element should be same as the identifier of the entry.  
-In addition, the following attributes can be present:
-+ "name" - Required - The user-friendly name of the entry, that will be displayed to the user in the GUI. Can use value refrences.
-+ "multiple" - Optional - specifies that the element represents multiple entries in the file, that share a common structure. Can have th following values:  
+In addition, the following attributes can be present:  
++ "name" - Required - The user-friendly name of the entry, that will be displayed to the user in the GUI. Can use value refrences.  
++ "multiple" - Optional - specifies that the element represents multiple entries in the file, that share a common structure. Can have the following values:  
   * "same" - All the entries share the same name  
   * "blank" - All the entries have no identifiers  
   * "number" - All the entries have different numbers as their identifiers  
@@ -76,9 +78,9 @@ In addition, the following attributes can be present:
 Elements describing value entries should have no children.
 Value entries can have the additional attributes:  
 + "type" - Recommended - the type of this value. Can have the following values:  
-  * "string" - The value is delimited by quotation marks ('"'). This is the only type the matters for the base program  
+  * "string" - The value is delimited by quotation marks ('"'). This is the only type the matters for the base program.  
   * "number" - The value is a number (can be fractional)  
-  * "date" - The value is a date, in a year.month.day format
+  * "date" - The value is a date, in a year.month.day format  
   * "misc" - the value is of a miscellanous type. If none of the above are specified, this is assumed  
 + "link" - Optional - A link containing a refrence to another entry, which is related to this one  
 

--- a/FormatSpec.md
+++ b/FormatSpec.md
@@ -1,89 +1,91 @@
-#CK2Editor XML Format File Specification
+# CK2Editor XML Format File Specification
   
   
-###Overview
+### Overview
 CK2Editor reads CK2 files based on pre-defined format files, written in xml.  
 If the format file is missing information about parts of the file, the program will try its best to guess the missing information, but is prone to fail in some circumstances and cannot rely on this ability alone.  
 
 The full format specification can be found in this document.
 
-###Terminology
+### Terminology
 I realize there might be confusion between the different terms used in this document, so here is a clarification:  
 + "The file" / "The save file" - the CK2txt file that is being read. Not to be confused with "the format file"!  
 + "The format file" - the XML file that describes the format of the file  
 + "The (base) program" - The non-graphical part of CK2Editor  
 + "The GUI" - The graphical editing program  
-+ "Value" - An identifier-value pair in the file, like "type=66"  
-+ "Section" - A section of the file delimited by curly brakcets ('{ }'), also with an identifier ("player={...}")  
++ "Value" - An identifier-value pair in the file, like `type=66`  
++ "Section" - A section of the file delimited by curly brakcets (`{ }`), also with an identifier (`player={...}`)  
 + "Entry" - A value or section  
 + "Element" - an XML element in the format file  
 + "Attribute" - an XML attribute of an element  
 
 This terminology is also applied in the documentation and inline code comments.
 
-###Top Structure
-The format file must contain a root element called "File". This represents the entire file after the CK2txt header, and all entries should be decendants of this element.  
-before the "File" element, an XML declaration is recommended.  
+### Top Structure
+The format file must contain a root element called `File`. This represents the entire file after the CK2txt header, and all entries should be decendants of this element.  
+before the `File` element, an XML declaration is recommended.  
 
-###References
-Some attributes allow refrences or value refrences. These are refrences to other entries that are related to the current entry. Normal references refrence an entry itself, and value refrences refrence related strings.
+### References
+Some attributes allow references or value references. These are references to other entries that are related to the current entry. Normal references reference an entry itself, and value references reference related strings.
 
-#####Symbols
-Refrences can contain symbols, which are strings related to the entries the refrence path started at or is at now. Below is a list of valid symbols:  
+##### Symbols
+references can contain symbols, which are strings related to the entries the reference path started at or is at now. Below is a list of valid symbols:  
 + `[THISNAME]` - The internal name of the entry the path started at  
 + `[THISVNAME]` - The user-friendly ("visual") name of the entry the path started at  
 + `[THISVALUE]` - The value of the entry the path started at
 
-#####Normal Refrences
-The syntax of normal refrences is as follows:  
-+ The path starts from the current entry, unless it starts with a '!' in which case it jumps to the the root (the "file" element in the format file)
-+ A forward slash ('/') seperates entries in the path
+##### Normal References
+The syntax of normal references is as follows:  
++ The path starts from the current entry, unless it starts with a `!` in which case it jumps to the the root (the `file` element in the format file)
++ A forward slash (`/`) seperates entries in the path
 + An entry name takes the path into that entry
-+ two dots ("..") take the path to the current entry's parent
++ two dots (`..`) take the path to the current entry's parent
 
-#####Value Refrences
-Value refrences are based on normal refrences, but evaluate to strings. The syntax of value refrences is as follows:  
-+ The refrence is delimited by the sequences `[!` and `!]`  
-+ The refrence contains a notmal refrence  
-+ At the end of the normal refrences, there will be a colon (':') followed by one of the following special symbols:  
+##### Value References
+Value references are based on normal references, but evaluate to strings. The syntax of value references is as follows:  
++ The reference is delimited by the sequences `[!` and `!]`  
++ The reference contains a notmal reference  
++ At the end of the normal references, there will be a colon (':') followed by one of the following special symbols:  
   * `[NAME]` - The internal name of the current entry  
   * `[VNAME]` - The user-friendly ("visual") name of the current entry  
   * `[VALUE]` - The value of the current entry  
   
-Multiple and nested value refrences are supported.
+Multiple and nested value references are supported.
 
-#####Example
-For example, the following value refrence, as the "name" attribute of a value conataining a character id:
+##### Example
+For example, the following value reference, as the `name` attribute of a value conataining a character id:
 >`[!!/character/[THISVALUE]:[VNAME]!]`  
 
 will evaluate to the user-friendly name of the character, because:  
-1. `[!..!]` - value refrence  
+1. `[!..!]` - value reference  
 2. `!` - start from the root  
-3. `/character/[THISVALUE]` - go to the section named the same as the value of this entry in the "character" section  
+3. `/character/[THISVALUE]` - go to the section named the same as the value of this entry in the `character` section  
 4. `:[VNAME]` - get the user-friendly name of that section
 
-###General Entry syntax
+### General Entry syntax
 Elements in the format file should correspond to entries in the file. The name of the element should be same as the identifier of the entry.  
 In addition, the following attributes can be present:  
-+ "name" - Required - The user-friendly name of the entry, that will be displayed to the user in the GUI. Can use value refrences.  
-+ "multiple" - Optional - specifies that the element represents multiple entries in the file, that share a common structure. Can have the following values:  
-  * "same" - All the entries share the same name  
-  * "blank" - All the entries have no identifiers  
-  * "number" - All the entries have different numbers as their identifiers  
-  * "different" - All the entries have different, unrelated names. Causes all the entries in the current section to be associated with the element  
++ `name` - Required - The user-friendly name of the entry, that will be displayed to the user in the GUI. Can use value references.  
++ `multiple` - Optional - specifies that the element represents multiple entries in the file, that share a common structure. Can have the following values:  
+  * `same` - All the entries share the same name  
+  * `blank` - All the entries have no identifiers  
+  * `number` - All the entries have different numbers as their identifiers  
+  * `different` - All the entries have different, unrelated names. Causes all the entries in the current section to be associated with the element  
+    
++ `grouper-name` - Required on elements that specify the `multiple` attribute - The user-friendly name of the grouper section which will be used in the GUI to group all entries which share this element. The value of this attribute should be put in parentheses so the user can distinguish it from real sections, but this is not enforced.  
   
-  The name of an element with a multiple attribute of anything but "same" will be ignored  
+  The name of an element with a multiple attribute of anything but `same` will be ignored  
 
-###Value Entry Syntax
+### Value Entry Syntax
 Elements describing value entries should have no children.
 Value entries can have the additional attributes:  
-+ "type" - Recommended - the type of this value. Can have the following values:  
-  * "string" - The value is delimited by quotation marks ('"'). This is the only type the matters for the base program.  
-  * "number" - The value is a number (can be fractional)  
-  * "date" - The value is a date, in a year.month.day format  
-  * "misc" - the value is of a miscellanous type. If none of the above are specified, this is assumed  
-+ "link" - Optional - A link containing a refrence to another entry, which is related to this one  
++ `type` - Recommended - the type of this value. Can have the following values:  
+  * `string` - The value is delimited by quotation marks ('"'). This is the only type the matters for the base program.  
+  * `number` - The value is a number (can be fractional)  
+  * `date` - The value is a date, in a year.month.day format  
+  * `misc` - the value is of a miscellanous type. If none of the above are specified, this is assumed  
++ `link` - Optional - A link containing a reference to another entry, which is related to this one  
 
-###Section Entry Syntax
+### Section Entry Syntax
 Elements describing section entries should have children.
 Sections currently do not have special attributes.  

--- a/FormatStubGenerator/Program.cs
+++ b/FormatStubGenerator/Program.cs
@@ -109,8 +109,11 @@ namespace FormatStubGenerator
 
                 string type = FormattedReader.DetectType(scope, childPair);
                 string name;
+                XmlAttribute grouperName = null;
                 if (multiple != null)
                 {
+                    grouperName = doc.CreateAttribute("grouper-name");
+                    grouperName.Value = "";
                     switch (multiple.Value)
                     {
                         case "number":
@@ -124,6 +127,7 @@ namespace FormatStubGenerator
                             break;
                         default:
                             name = childPair.Value;
+                            grouperName.Value = Util.UppercaseWords(childPair.Value + "s");
                             break;
                     }
                 }
@@ -135,7 +139,10 @@ namespace FormatStubGenerator
                 natt.Value = Util.UppercaseWords(name.Replace('_', ' '));
                 node.Attributes.Append(natt);
                 if (multiple != null)
+                {
                     node.Attributes.Append(multiple);
+                    node.Attributes.Append(grouperName);
+                }
                 parent.AppendChild(node);
                 if (type == "section")
                 {

--- a/Todo.txt
+++ b/Todo.txt
@@ -1,7 +1,6 @@
 Implement full search
-Implement Adding new Entries
 Improve file loading UX
-Add support for nested refrences
+Add support for nested references
 Group entries with the "multiple" attribute together
 Fix saving
 Add support for non-basic structures

--- a/Todo.txt
+++ b/Todo.txt
@@ -1,7 +1,6 @@
 Implement full search
 Improve file loading UX
 Add support for nested references
-Add friendly names for groupers
 Fix saving
 Add support for non-basic structures
 Add support for recursive structures (like the "from" structure inside opinion modifiers)

--- a/Todo.txt
+++ b/Todo.txt
@@ -1,6 +1,7 @@
 Implement full search
 Improve file loading UX
 Add support for nested references
-Group entries with the "multiple" attribute together
+Add friendly names for groupers
 Fix saving
 Add support for non-basic structures
+Add support for recursive structures (like the "from" structure inside opinion modifiers)


### PR DESCRIPTION
Groups entries sharing the same node with the "multiple" attributes together.

Massively reduces clutter in the GUI in cases where grouped entries are not in their own section (for example, dyn_title right at the beginning), which in turn improves navigation around the file.

FormatStubGenerator is also updated to reflect the change in the spec.
